### PR TITLE
Adding python-qt4

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,6 +61,7 @@ if [ ! -z $APT_GET_CMD ]; then
   $APT_GET_CMD install postgresql postgresql-contrib
   $APT_GET_CMD install python-psycopg2
   $APT_GET_CMD install libpq-dev
+  $APT_GET_CMD install python-qt4 # Install PyQt4
 
   echo "configure PostgreSQL"
   # configure PostgreSQL


### PR DESCRIPTION
Fix #55 Import PyQt4 to fix environment error for systems that do not have GUIs.
OpenCV assumes the environment has a GUI, but Ubuntu Server not have a GUI by default.